### PR TITLE
Fix numbers with preceding 0's not tokenizing correctly

### DIFF
--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -79,12 +79,9 @@ def tokenize(program: str) -> list[Tokenlike]:
 
         # Number handling
         elif scroller.pointer in "/\\":
-            number = tokenize_number(scroller)
+            number, length = tokenize_number(scroller)
             tokens.append(number)
-            scroller.shift(
-                log(number + 1, 2).__ceil__() or 1
-            )
-
+            scroller.shift(length)
         else:
             with suppress(ValueError):
                 tokens.append(Token(scroller.pointer))
@@ -93,14 +90,14 @@ def tokenize(program: str) -> list[Tokenlike]:
     return exclude_comments(tokens)
 
 
-def tokenize_number(scroller: handlers.Scroller) -> int:
+def tokenize_number(scroller: handlers.Scroller) -> tuple[int, int]:
     temp = ""
     for char in scroller.program:
         if char not in "/\\":
             break
         temp += char
     temp = temp.replace("/", "1").replace("\\", "0")
-    return int(temp, 2)
+    return int(temp, 2), len(temp)
 
 
 def exclude_comments(tokens: list[Tokenlike]) -> list[Tokenlike]:


### PR DESCRIPTION
Since the `tokenize_number` creates a temp var which populates with the translated values, it is possible to just return the size of that, and then shift the scroller with that length instead of using the algorithm which I fail to understand :trollface:.