### PR TITLE
Improve install method for the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation on how to program in Samarium can be found [here](docs/tableofcont
 
 ## [AUR](https://aur.archlinux.org/)
 
-`yay -S samarium`
+`git clone https://aur.archlinux.org/samarium.git; cd samarium; makepkg -sirc` or use your favorite [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
 
 ## Using Samarium
 
@@ -39,6 +39,6 @@ There is also a VSCode syntax highlighting extension for Samarium, which can be 
 # Credits
 
 Samarium was inspired by several languages, including [brainfuck](https://esolangs.org/wiki/Brainfuck), [Rust](https://www.rust-lang.org/), [Java](https://www.java.com/) and [Python](https://www.python.org/).
-Thanks to [tetraxile](https://github.com/tetraxile) for helping with design choices and writing the docs, [MithicSpirit](https://github.com/MithicSpirit) for making Samarium an AUR package, and [DarviL82](https://github.com/DarviL82) for fixing some issues.
+Thanks to [tetraxile](https://github.com/tetraxile) for helping with design choices and writing the docs, [MithicSpirit](https://github.com/MithicSpirit) for making an AUR package for Samarium, and [DarviL82](https://github.com/DarviL82) for fixing some issues.
 
 If you have any questions, or would like to get in touch, join the [Discord server](https://discord.gg/C8QE5tVQEq)!


### PR DESCRIPTION
`yay` (and all other AUR helpers) are not officially supported. The only official way to install packages is through `makepkg`, so this is what should be presented as the standard installation method. Furthermore, there are many available AUR helpers, none of which have become any form of standard---`yay` was quite popular but `paru` is now rapidly rising in popularity, not to mention `pamac`, Manjaro's default "package manager" (pacman GUI frontend + AUR helper + _etc._).

Also fixes a very minor qualm I had about the grammatical structure of the phrase about me making the AUR package and adds a trailing newline to the file because someone is using a bad editor (/hj).