### PR TITLE
code blocks in docs should always have a dark background 

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,3 @@
+code {
+  --md-code-bg-color: reset !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,8 @@ theme:
 extra_javascript:
   - https://unpkg.com/shiki@0.10.1/dist/index.unpkg.iife.js
   - assets/script.js
+extra_css:
+  - assets/style.css
 markdown_extensions:
   - admonition
   - pymdownx.superfences:


### PR DESCRIPTION
Currently when using light theme, the code changes its background to a light colour. This would make sense normally but the theme used for highlighting is not suited for a light background. These commits make sure it is consistent.