### PR TITLE
Replace usage of `os` in src/core.py with `pathlib`

### DIFF
--- a/src/samarium/__init__.py
+++ b/src/samarium/__init__.py
@@ -1,7 +1,8 @@
 import sys
+from pathlib import Path
 from contextlib import suppress
 
-from .core import readfile, run
+from .core import run
 from .shell import run_shell
 from .transpiler import Registry
 from .utils import __version__
@@ -33,7 +34,7 @@ def main(debug: bool = False):
         sys.exit()
 
     try:
-        file = readfile(arg)
+        file = Path(arg).read_text()
     except IOError:
         print(f"file not found: {arg}")
     else:

--- a/src/samarium/core.py
+++ b/src/samarium/core.py
@@ -29,7 +29,7 @@ from .classes import (
 from .runtime import Runtime
 from .tokenizer import tokenize
 from .transpiler import Registry, Transpiler
-from .utils import readfile, silence_stdout, sysexit
+from .utils import silence_stdout
 
 MODULE_NAMES = [
     "collections",
@@ -77,7 +77,7 @@ def import_module(data: str, reg: Registry) -> None:
         path = Path(__file__).absolute().parent / "modules"
 
     with silence_stdout():
-        imported = run(readfile(path / f"{name}.sm"), Registry(globals()))
+        imported = run((path / f"{name}.sm").read_text(), Registry(globals()))
 
     if module_import:
         reg.vars.update({f"sm_{name}": Module(name, imported.vars)})
@@ -127,7 +127,7 @@ def run(
     Runtime.quit_on_error = quit_on_error
     code = Transpiler(tokenize(code), reg).transpile().output
     if load_template:
-        code = readfile(Path(__file__).resolve().parent / "template.py").replace(
+        code = (Path(__file__).resolve().parent / "template.py").read_text().replace(
             "{{ CODE }}", code
         )
     try:

--- a/src/samarium/core.py
+++ b/src/samarium/core.py
@@ -71,7 +71,7 @@ def import_module(data: str, reg: Registry) -> None:
     except IndexError:  # REPL
         path = Path().absolute()
 
-    if f"{name}.sm" not in list(path.iterdir()):
+    if f"{name}.sm" not in [e.name for e in path.iterdir()]:
         if name not in MODULE_NAMES:
             raise exc.SamariumImportError(f"invalid module: {name}")
         path = Path(__file__).absolute().parent / "modules"

--- a/src/samarium/core.py
+++ b/src/samarium/core.py
@@ -127,7 +127,7 @@ def run(
     Runtime.quit_on_error = quit_on_error
     code = Transpiler(tokenize(code), reg).transpile().output
     if load_template:
-        code = readfile(Path(__file__).resolve().parent / 'template.py').replace(
+        code = readfile(Path(__file__).resolve().parent / "template.py").replace(
             "{{ CODE }}", code
         )
     try:

--- a/src/samarium/core.py
+++ b/src/samarium/core.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sys
 from datetime import datetime
 from time import sleep as _sleep
@@ -67,17 +67,17 @@ def import_module(data: str, reg: Registry) -> None:
         sys.stderr.write(dahlia("&4[RecursionError]\n"))
         return
     try:
-        path = sys.argv[1][: sys.argv[1].rfind("/") + 1] or "."
+        path = Path(sys.argv[1][: sys.argv[1].rfind("/") + 1] or ".")
     except IndexError:  # REPL
-        path = os.getcwd() + "/"
+        path = Path().absolute()
 
-    if f"{name}.sm" not in os.listdir(path):
+    if f"{name}.sm" not in list(path.iterdir()):
         if name not in MODULE_NAMES:
             raise exc.SamariumImportError(f"invalid module: {name}")
-        path = os.path.join(os.path.dirname(__file__), "modules")
+        path = Path(__file__).absolute().parent / 'modules'
 
     with silence_stdout():
-        imported = run(readfile(f"{path}/{name}.sm"), Registry(globals()))
+        imported = run(readfile(path / f"{name}.sm"), Registry(globals()))
 
     if module_import:
         reg.vars.update({f"sm_{name}": Module(name, imported.vars)})
@@ -127,7 +127,7 @@ def run(
     Runtime.quit_on_error = quit_on_error
     code = Transpiler(tokenize(code), reg).transpile().output
     if load_template:
-        code = readfile(f"{os.path.dirname(__file__)}/template.py").replace(
+        code = readfile(Path(__file__).resolve().parent / 'template.py').replace(
             "{{ CODE }}", code
         )
     try:

--- a/src/samarium/core.py
+++ b/src/samarium/core.py
@@ -74,7 +74,7 @@ def import_module(data: str, reg: Registry) -> None:
     if f"{name}.sm" not in list(path.iterdir()):
         if name not in MODULE_NAMES:
             raise exc.SamariumImportError(f"invalid module: {name}")
-        path = Path(__file__).absolute().parent / 'modules'
+        path = Path(__file__).absolute().parent / "modules"
 
     with silence_stdout():
         imported = run(readfile(path / f"{name}.sm"), Registry(globals()))

--- a/src/samarium/utils.py
+++ b/src/samarium/utils.py
@@ -93,11 +93,6 @@ def match_brackets(tokens_: list[Tokenlike]) -> tuple[int, list[Token]]:
     return 0, []
 
 
-def readfile(path: str) -> str:
-    with open(path) as f:
-        return f.read()
-
-
 def run_with_backup(main: Callable[..., T], backup: Callable[..., T], *args) -> T:
     with suppress(NotDefinedError):
         return main(*args)


### PR DESCRIPTION
Pretty straightforward. Could use some more testing; I'm not able to really run the import functionality through its paces.

Gave up on poetry; switched to good ol' venv.

![image](https://user-images.githubusercontent.com/772507/193437064-91515487-c594-48bc-98ee-6262ca91d2c7.png)

Also, I don't know why `to_upper` doesn't actually have an effect, but it's that way before and after.

https://github.com/samarium-lang/Samarium/issues/30